### PR TITLE
Escape pipes in markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Continue by installing the following tools using [Windows Terminal](https://www.
 
 | Tool | Purpose | Command                                                                                           |
 | :-------- | :-------- | :------------------------------------------------------------------------------------------------ |
-| :snake: **uv** (installed in WSL2) | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh | sh` <br> `source ~/.bashrc` |
+| :snake: **uv** (installed in WSL2) | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh \| sh` <br> `source ~/.bashrc` |
 | :octocat: **Git** (installed in WSL2) | Version Control | `sudo apt update && sudo apt upgrade` <br> `sudo apt install git-all`   |
 | :memo: **VS Code** (installed in Windows) | Development Environment | [Download](https://code.visualstudio.com/download) |
 | :memo: **Cursor** | Development Environment | [Download](https://www.cursor.com/downloads) |
@@ -144,7 +144,7 @@ Continue by installing the following tools using [Windows Terminal](https://www.
 Open terminal using <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>. Enter the following commands in terminal to setup your environment.
 | Tool | Purpose | Command                                                                                           |
 | :-------- | :-------- | :------------------------------------------------------------------------------------------------ |
-| :snake: **uv**  | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh | sh` <br> `source ~/.bashrc` |
+| :snake: **uv**  | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh \| sh` <br> `source ~/.bashrc` |
 | :octocat: **Git**  | Version Control | `sudo apt update && sudo apt upgrade` <br> `sudo apt install git-all`   |
 | :memo: **VS Code** | Development Environment | [Download](https://code.visualstudio.com/download) |
 | :memo: **Cursor** | Development Environment | [Download](https://www.cursor.com/downloads) |
@@ -175,7 +175,7 @@ Enter the following commands in terminal to setup your environment.
 
 | Tool | Purpose | Command                                                                                           |
 | :-------- | :-------- | :------------------------------------------------------------------------------------------------ |
-| :snake: **uv**  | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh | sh` <br> `source ~/.bashrc` |
+| :snake: **uv**  | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh \| sh` <br> `source ~/.bashrc` |
 | :octocat: **Git**  | Version Control | `brew install git`   |
 | :memo: **VS Code** | Development Environment | [Download](https://code.visualstudio.com/download) |
 | :memo: **Cursor** | Development Environment | [Download](https://www.cursor.com/downloads) |
@@ -212,7 +212,7 @@ Now let's install uv and other tools:
 
 | Tool | Purpose | Command                                                                                           |
 | :-------- | :-------- | :------------------------------------------------------------------------------------------------ |
-| :snake: **uv**  | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh | sh` |
+| :snake: **uv**  | Python Package Manager | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | :octocat: **Git**  | Version Control | `brew install git`   |
 | :memo: **VS Code** | Development Environment | [Download](https://code.visualstudio.com/download) |
 | :memo: **Cursor** | Development Environment | [Download](https://www.cursor.com/downloads) |


### PR DESCRIPTION
Without escaping, the commands to install uv are incomplete.

Before:

![image](https://github.com/user-attachments/assets/158471bb-3a0c-43bf-b7a0-3b1cdfd6874b)

After:

![image](https://github.com/user-attachments/assets/367ebc16-6779-490f-80ce-257788e70e7b)
